### PR TITLE
refactor: improve staggered reveal reduced-motion handling and tests [PUL-8]

### DIFF
--- a/app/components/Reveal.test.tsx
+++ b/app/components/Reveal.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Reveal } from './Reveal';
+
+describe('Reveal', () => {
+  it('passes delay to getRevealProps and merges classes/styles', () => {
+    const getRevealProps = vi.fn().mockReturnValue({
+      className: 'opacity-0 translate-y-3',
+      style: {
+        transitionDelay: '300ms',
+      },
+    });
+
+    render(
+      <Reveal
+        as="a"
+        href="#target"
+        className="base-class"
+        style={{ willChange: 'transform' }}
+        delay={300}
+        getRevealProps={getRevealProps}
+      >
+        Go
+      </Reveal>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Go' });
+
+    expect(getRevealProps).toHaveBeenCalledWith(300);
+    expect(link).toHaveClass('base-class');
+    expect(link).toHaveClass('opacity-0');
+    expect(link).toHaveStyle({ transitionDelay: '300ms', willChange: 'transform' });
+    expect(link).toHaveAttribute('href', '#target');
+  });
+});

--- a/app/hooks/useStaggerReveal.test.tsx
+++ b/app/hooks/useStaggerReveal.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setMatchMedia } from '../test-utils/setMatchMedia';
+import { useStaggerReveal } from './useStaggerReveal';
+
+describe('useStaggerReveal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  it('starts hidden and becomes visible after mount delay', () => {
+    setMatchMedia(false);
+    const { result } = renderHook(() => useStaggerReveal({ mountDelay: 100 }));
+
+    const initialReveal = result.current.getRevealProps(250);
+    expect(initialReveal.className).toBe('opacity-0 translate-y-3');
+    expect(initialReveal.style).toMatchObject({
+      transitionDelay: '250ms',
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current.getRevealProps(250).className).toBe('opacity-100 translate-y-0');
+  });
+
+  it('returns static visible props when reduced motion is preferred', () => {
+    setMatchMedia(true);
+    const { result } = renderHook(() => useStaggerReveal({ mountDelay: 100 }));
+
+    expect(result.current.getRevealProps(300)).toEqual({
+      className: 'opacity-100 translate-y-0',
+      style: {},
+    });
+  });
+
+  it('updates reveal state when reduced motion preference changes after mount', () => {
+    const mediaQuery = setMatchMedia(false);
+    const { result } = renderHook(() => useStaggerReveal({ mountDelay: 100 }));
+
+    expect(result.current.getRevealProps(300).className).toBe('opacity-0 translate-y-3');
+
+    act(() => {
+      mediaQuery.setMatches(true);
+    });
+
+    expect(result.current.getRevealProps(300)).toEqual({
+      className: 'opacity-100 translate-y-0',
+      style: {},
+    });
+  });
+});

--- a/app/hooks/useStaggerReveal.ts
+++ b/app/hooks/useStaggerReveal.ts
@@ -12,21 +12,46 @@ type UseStaggerRevealOptions = {
   mountDelay?: number;
 };
 
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const hiddenClasses = 'opacity-0 translate-y-3';
+const visibleClasses = 'opacity-100 translate-y-0';
+
 const transitionStyles = {
   transitionProperty: 'opacity, transform',
   transitionDuration: '450ms',
   transitionTimingFunction: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
 } as const;
 
+function getPrefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function subscribeReducedMotionChange(
+  mediaQuery: MediaQueryList,
+  listener: (event: MediaQueryListEvent) => void,
+) {
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', listener);
+
+    return () => {
+      mediaQuery.removeEventListener('change', listener);
+    };
+  }
+
+  mediaQuery.addListener(listener);
+
+  return () => {
+    mediaQuery.removeListener(listener);
+  };
+}
+
 export function useStaggerReveal({ mountDelay = 100 }: UseStaggerRevealOptions = {}) {
   const [isMounted, setIsMounted] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return false;
-    }
-
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  });
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(getPrefersReducedMotion);
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') {
@@ -34,18 +59,18 @@ export function useStaggerReveal({ mountDelay = 100 }: UseStaggerRevealOptions =
       return () => window.clearTimeout(timeoutId);
     }
 
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
 
     const onChange = (event: MediaQueryListEvent) => {
       setPrefersReducedMotion(event.matches);
     };
 
-    mediaQuery.addEventListener('change', onChange);
+    const unsubscribe = subscribeReducedMotionChange(mediaQuery, onChange);
 
     const timeoutId = window.setTimeout(() => setIsMounted(true), mountDelay);
 
     return () => {
-      mediaQuery.removeEventListener('change', onChange);
+      unsubscribe();
       window.clearTimeout(timeoutId);
     };
   }, [mountDelay]);
@@ -54,13 +79,13 @@ export function useStaggerReveal({ mountDelay = 100 }: UseStaggerRevealOptions =
     (delay = 0): RevealProps => {
       if (prefersReducedMotion) {
         return {
-          className: 'opacity-100 translate-y-0',
+          className: visibleClasses,
           style: {},
         };
       }
 
       return {
-        className: isMounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3',
+        className: isMounted ? visibleClasses : hiddenClasses,
         style: {
           ...transitionStyles,
           transitionDelay: `${delay}ms`,

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,12 +1,56 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import Home from "./page";
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe("Home page", () => {
-  it("renders main hero heading", () => {
+import Home from './page';
+import { setMatchMedia } from './test-utils/setMatchMedia';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => {
+    vi.runOnlyPendingTimers();
+  });
+  vi.useRealTimers();
+});
+
+describe('Home page', () => {
+  it('renders main hero heading', () => {
+    setMatchMedia(false);
+
     render(<Home />);
+
     expect(
-      screen.getByRole("heading", { name: /hi, i'm juan manuel/i }),
+      screen.getByRole('heading', { name: /hi, i'm juan manuel/i }),
     ).toBeInTheDocument();
+  });
+
+  it('reveals nav items after mount delay when reduced motion is disabled', () => {
+    setMatchMedia(false);
+
+    render(<Home />);
+    const aboutLink = screen.getByRole('link', { name: 'About' });
+    const navItem = aboutLink.closest('li');
+
+    expect(navItem).toHaveClass('opacity-0');
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(navItem).toHaveClass('opacity-100');
+  });
+
+  it('renders motion-safe visible states when reduced motion is enabled', () => {
+    setMatchMedia(true);
+
+    render(<Home />);
+
+    const aboutLink = screen.getByRole('link', { name: 'About' });
+    const navItem = aboutLink.closest('li');
+
+    expect(navItem).toHaveClass('opacity-100');
+    expect(navItem).not.toHaveClass('opacity-0');
   });
 });

--- a/app/test-utils/setMatchMedia.ts
+++ b/app/test-utils/setMatchMedia.ts
@@ -1,0 +1,59 @@
+type MatchMediaController = {
+  setMatches: (nextMatches: boolean) => void;
+};
+
+type MatchMediaListener = (event: MediaQueryListEvent) => void;
+
+export function setMatchMedia(initialMatches: boolean): MatchMediaController {
+  let matches = initialMatches;
+  const listeners = new Set<MatchMediaListener>();
+
+  const emitChange = (media: string) => {
+    const event = { matches, media } as MediaQueryListEvent;
+
+    listeners.forEach(listener => {
+      listener(event);
+    });
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string): MediaQueryList => ({
+      get matches() {
+        return matches;
+      },
+      media: query,
+      onchange: null,
+      addListener: listener => {
+        listeners.add(listener);
+      },
+      removeListener: listener => {
+        listeners.delete(listener);
+      },
+      addEventListener: (eventName, listener) => {
+        if (eventName === 'change' && typeof listener === 'function') {
+          listeners.add(listener as MatchMediaListener);
+        }
+      },
+      removeEventListener: (eventName, listener) => {
+        if (eventName === 'change' && typeof listener === 'function') {
+          listeners.delete(listener as MatchMediaListener);
+        }
+      },
+      dispatchEvent: event => {
+        listeners.forEach(listener => {
+          listener(event as MediaQueryListEvent);
+        });
+        return true;
+      },
+    }),
+  });
+
+  return {
+    setMatches: nextMatches => {
+      matches = nextMatches;
+      emitChange('(prefers-reduced-motion: reduce)');
+    },
+  };
+}


### PR DESCRIPTION
## Summary
This PR refines the staggered reveal animation implementation and test coverage, with a focus on reduced-motion behavior and cross-browser `matchMedia` compatibility.

Closes #8

## What changed
- Refactored `useStaggerReveal`:
- Added constants for reduced-motion query and reveal class states.
- Extracted reduced-motion initialization into a dedicated helper.
- Added media-query subscription helper with support for both `addEventListener` and legacy `addListener`.
- Kept animation behavior unchanged while improving maintainability and compatibility.

- Improved test utilities:
- Added shared `setMatchMedia` helper under `app/test-utils`.
- Extended helper to simulate runtime `prefers-reduced-motion` changes.

- Expanded tests:
- Added `Reveal` component tests.
- Added `useStaggerReveal` hook tests.
- Added coverage for reduced-motion toggle updates after mount.
- Updated homepage tests to use the shared media-query utility.

## Validation
- `pnpm test` ✅ (7 tests passing)
- `pnpm lint` ✅

## Notes
- This is a single cohesive refactor commit for ticket `PUL-8`.
